### PR TITLE
Fix getBandwidth calculation error

### DIFF
--- a/src/lib/trx.js
+++ b/src/lib/trx.js
@@ -430,7 +430,7 @@ export default class Trx {
         this.tronWeb.fullNode.request('wallet/getaccountnet', {
             address
         }, 'post').then(({freeNetUsed = 0, freeNetLimit = 0, NetUsed = 0, NetLimit = 0}) => {
-            callback(null, (freeNetLimit - freeNetUsed) + (NetLimit - NetUsed));
+            callback(null, Math.max(freeNetLimit - freeNetUsed, 0) + Math.max(NetLimit - NetUsed, 0));
         }).catch(err => callback(err));
     }
 


### PR DESCRIPTION
When the bandwidth is unfrozen, NetUsed may be greater than NetLimit, resulting in incorrect calculation of the getBandwidth result