### PR TITLE
Fix: Replace triggerSmartContract with triggerConstantContract in method _call function

### DIFF
--- a/src/lib/contract/method.js
+++ b/src/lib/contract/method.js
@@ -99,7 +99,7 @@ export default class Method {
             value
         }));
 
-        this.tronWeb.transactionBuilder.triggerSmartContract(
+        this.tronWeb.transactionBuilder.triggerConstantContract(
             this.contract.address,
             this.functionSelector,
             options,
@@ -110,7 +110,7 @@ export default class Method {
                     return callback(err);
 
                 if (!utils.hasProperty(transaction, 'constant_result'))
-                    return callback('Failed to execute');
+                    return callback('Failed to execute' + JSON.stringify(transaction));
 
                 try {
 


### PR DESCRIPTION
I encounter an error when I Instantiate a Contract with tronWeb.contract(abi, address): All "view" functions were called with triggerSmartContract instead of triggerConstantContract.
Also this error was not descriptive.
I have solved it in this PR.