### PR TITLE
Update transactionBuilder.js

### DIFF
--- a/src/lib/transactionBuilder.js
+++ b/src/lib/transactionBuilder.js
@@ -884,15 +884,12 @@ export default class TransactionBuilder {
             args.parameter = parameters;
         }
 
-
-        if (!options._isConstant) {
-            args.call_value = parseInt(callValue)
-            args.fee_limit = parseInt(feeLimit)
-            if (utils.isNotNullOrUndefined(tokenValue))
-                args.call_token_value = parseInt(tokenValue)
-            if (utils.isNotNullOrUndefined(tokenId))
-                args.token_id = parseInt(tokenId)
-        }
+        args.call_value = parseInt(callValue)
+        args.fee_limit = parseInt(feeLimit)
+        if (utils.isNotNullOrUndefined(tokenValue))
+            args.call_token_value = parseInt(tokenValue)
+        if (utils.isNotNullOrUndefined(tokenId))
+            args.token_id = parseInt(tokenId)
 
         if (options.permissionId) {
             args.Permission_id = options.permissionId;

--- a/src/lib/transactionBuilder.js
+++ b/src/lib/transactionBuilder.js
@@ -885,11 +885,14 @@ export default class TransactionBuilder {
         }
 
         args.call_value = parseInt(callValue)
-        args.fee_limit = parseInt(feeLimit)
-        if (utils.isNotNullOrUndefined(tokenValue))
-            args.call_token_value = parseInt(tokenValue)
-        if (utils.isNotNullOrUndefined(tokenId))
-            args.token_id = parseInt(tokenId)
+
+        if (!options._isConstant) {
+            args.fee_limit = parseInt(feeLimit)
+            if (utils.isNotNullOrUndefined(tokenValue))
+                args.call_token_value = parseInt(tokenValue)
+            if (utils.isNotNullOrUndefined(tokenId))
+                args.token_id = parseInt(tokenId)
+        }
 
         if (options.permissionId) {
             args.Permission_id = options.permissionId;


### PR DESCRIPTION
When trying to get estimated energy via constantContract, it returnes very small (wrong) value, because call_value variable is not passed in args. This update will fix it.
Why actually call_valu, fee_limit, token_id and call_token_value are not included in current version? Whats the reason?

Example without call value (current version where call value is excluded form constantContract call)
Request:
![image](https://user-images.githubusercontent.com/93192858/160132482-a3ec9ad8-2f74-4bc3-b27c-ae8809e63a36.png)
Response (decoded error: "REVERT opcode executed"):
![image](https://user-images.githubusercontent.com/93192858/160132542-7e9ff51c-829d-4b75-a1e1-e35881cc26b8.png)

Example with call value (changes made in this pull request):
Request:
![image](https://user-images.githubusercontent.com/93192858/160131888-68720973-7bed-4a88-bf6b-848d9948b675.png)
Response:
![image](https://user-images.githubusercontent.com/93192858/160131960-91de7634-f241-420f-b018-3773f2eb34da.png)
