### PR TITLE
Modify loadAbi() regex to skip Error statement

### DIFF
--- a/src/lib/contract/index.js
+++ b/src/lib/contract/index.js
@@ -107,7 +107,8 @@ export default class Contract {
 
         abi.forEach(func => {
             // Don't build a method for constructor function. That's handled through contract create.
-            if (!func.type || /constructor/i.test(func.type))
+            // Don't build a method for error function.
+            if (!func.type || /constructor|error/i.test(func.type))
                 return;
 
             const method = new Method(this, func);


### PR DESCRIPTION
Error statement introduce since 0.8.4
https://blog.soliditylang.org/2021/04/21/custom-errors/

TronWeb loadAbi trying to build function from contract implemented Error statement and cause `Error: no matching function (argument="name", value="AnyError", code=INVALID_ARGUMENT, version=abi/5.7.0)`

Change `/constructor/i` to `/constructor|error/i` can prevent error during contract initialize.