### PR TITLE
fix: TronWeb not usable within ServiceWorkers in Browser extensions

### DIFF
--- a/src/lib/providers/HttpProvider.ts
+++ b/src/lib/providers/HttpProvider.ts
@@ -1,4 +1,4 @@
-import axios, { Method, RawAxiosRequestHeaders, AxiosHeaders, HeadersDefaults } from 'axios';
+import axios, {Method, RawAxiosRequestHeaders, AxiosHeaders, HeadersDefaults, getAdapter} from 'axios';
 import { hasProperties, isObject, isValidURL } from '../../utils/validations.js';
 
 export type HeadersType = RawAxiosRequestHeaders | AxiosHeaders | Partial<HeadersDefaults>;
@@ -35,6 +35,7 @@ export default class HttpProvider {
             baseURL: host,
             timeout: timeout,
             headers: headers,
+            adapter: getAdapter('xhr'),
             auth: user
                 ? {
                       username: user,


### PR DESCRIPTION
Identical to: https://github.com/tronprotocol/tronweb/pull/438

Just updated to Typescript and merged with Upstream. 

Tested again on 19 January 2024, with the latest tronweb release as well as the upcoming 6.0.0-beta.0 release. 

When using the built in adapter it works.

---

TronWeb currently can't be used in Browser Extension Service Workers due to Axios incompatibility with it.

There are usually two ways to fix this:

Convert to fetch
Add a fetch-adapter
Tests seem to run as they did before (some did fail for me before changing anything already).

Had to directly include https://github.com/vespaiach/axios-fetch-adapter
as it wasn't possible to use the package as is.
