### PR TITLE
Bugfix: Incorrect ABI handling with tuple inputs causes deployment and contract attachment failures

### DIFF
--- a/src/lib/contract/index.ts
+++ b/src/lib/contract/index.ts
@@ -57,6 +57,7 @@ export class Contract {
         this.props.forEach((prop: string) => delete (this as any)[prop]);
 
         abi.forEach((func) => {
+
             // Don't build a method for constructor function. That's handled through contract create.
             // Don't build a method for error function.
             if (!func.type || /constructor|error/i.test(func.type)) return;
@@ -134,7 +135,7 @@ export class Contract {
             this.bytecode = contract.bytecode;
             this.deployed = true;
 
-            this.loadAbi(contract.abi ? (contract.abi.entrys ? contract.abi.entrys : []) : []);
+            this.loadAbi(this.abi || contract.abi.entrys || []);
 
             return this;
         } catch (ex: any) {


### PR DESCRIPTION
This PR addresses an issue in both the `Contract` implementation and the interaction with fullNode that prevents successful deployment of contracts and attachment to existing ones.

## Root Cause

When a contract method accepts tuple-typed inputs, the fullNode returns an incomplete ABI definition via `wallet/getcontract`. Specifically, the components field (which defines the structure of the tuple) is missing. For example, for the contract `TYqLhdkv8LQgfy7gUeFUUqXdg7Af6aiXvp` on Shasta Testnet, the ABI includes:

```
{
  "name": "_swapDetails",
  "type": "tuple"
  // ⛔ missing "components"
}
```

Without components, the ABI cannot be parsed correctly, which causes failures downstream.

## Symptoms

### Deployment fails

TronWeb throws `Error: unknown function` during contract deployment via the new() method:

```
const tronFactory = tronWeb.contract(estimation.artifact.abi);
const contractInstance = await tronFactory.new({ ... });
``` 

Stack trace (truncated):

```
Error: Error: unknown function
    at Contract.at (...)
    ...
``` 

Prior to that, a lower-level parsing error is printed to stdout:

```
EE Error
    at new ParamType (...)
    at from (...)
    ...
``` 

###	Attaching to an existing contract fails

Even when a valid ABI is provided, using `tronWeb.contract(abi).at(address)` fails:

```ts
const instance = await tronWeb.contract(abi).at('TYqLhdkv8LQgfy7gUeFUUqXdg7Af6aiXvp');
```

This is because the `Contract` class still attempts to fetch and parse the ABI from the fullNode, which leads to a failure due to the malformed tuple definition.


### Proposed Fix

This PR ensures that if a valid ABI is explicitly provided by the user, it will always be used, bypassing the incomplete version returned by the fullNode. This allows:
- Successful deployments of contracts with complex input types
- Correct attachment to already-deployed contracts using externally supplied ABI