### PR TITLE
fix(#627): circular dependency issue for TypedDataEncoder

### DIFF
--- a/src/utils/typedData.ts
+++ b/src/utils/typedData.ts
@@ -1,4 +1,3 @@
-import { TronWeb } from '../tronweb.js';
 import {
     keccak256,
     recoverAddress,
@@ -18,13 +17,13 @@ import {
 } from 'ethers';
 import type { BigNumberish, BytesLike, SignatureLike } from 'ethers';
 
-import { ADDRESS_PREFIX_REGEX } from './address.js';
+import { ADDRESS_PREFIX_REGEX,toHex } from './address.js';
 
 function getAddress(address: string) {
-    return TronWeb.address.toHex(address).replace(ADDRESS_PREFIX_REGEX, '0x');
+    return toHex(address).replace(ADDRESS_PREFIX_REGEX, '0x');
 }
 function getTronAddress(address: string) {
-    return TronWeb.address.toHex(address);
+    return toHex(address);
 }
 
 const padding = new Uint8Array(32);


### PR DESCRIPTION
this is fix for issue #627, which crashes builds in turbopack due a circular import for `TypedDataEncoder`.
I ran this locally on my own codebase to confirm this does work without crashing now.