### PR TITLE
fix: transaction duplication within one block

### DIFF
--- a/src/lib/TransactionBuilder/helper.ts
+++ b/src/lib/TransactionBuilder/helper.ts
@@ -100,6 +100,11 @@ export async function createTransaction<T extends ContractParamter>(
     Permission_id?: number,
     options = {} as Partial<Omit<Transaction['raw_data'], 'contract'>>
 ): Promise<Transaction<T>> {
+    const blockHeader = {
+        ...(checkBlockHeader(options) ? ({} as Transaction['raw_data']) : await getHeaderInfo(tronWeb.fullNode)),
+        timestamp: Date.now(),
+    };
+
     const tx: Transaction<T> = {
         visible: false,
         txID: '',
@@ -114,7 +119,7 @@ export async function createTransaction<T extends ContractParamter>(
                     type,
                 },
             ],
-            ...(checkBlockHeader(options) ? ({} as Transaction['raw_data']) : await getHeaderInfo(tronWeb.fullNode)),
+            ...blockHeader,
             ...options,
         },
     };


### PR DESCRIPTION
### Problem
`getHeaderInfo` returns the block's timestamp. When building the same transaction within a single block , the same timestamp of the same block leads to duplicate transaction errors because the transaction ID/hash ends up identical.

### Changes
  - `timestamp` is explicitly overridden with `Date.now()` to ensure uniqueness when needed.

### Impact
- Reduces occurrences of duplicate transaction errors when creating transactions in quick succession.

