### PR TITLE
fix: send empty object instead of null for POST requests with no payload

### DIFF
--- a/src/lib/providers/HttpProvider.ts
+++ b/src/lib/providers/HttpProvider.ts
@@ -56,7 +56,7 @@ export default class HttpProvider {
 
         return this.instance
             .request<T>({
-                data: method == 'post' && Object.keys(payload).length ? payload : null,
+                data: method == 'post' ? payload : undefined,
                 params: method == 'get' && payload,
                 url,
                 method,


### PR DESCRIPTION
When payload is an empty object, Object.keys({}).length === 0 caused data to be set to null, which axios serializes as the JSON string "null" for application/json requests instead of sending {}. This affected methods like getChainParameters() and listExchanges() that pass {} as payload, causing downstream servers to receive null instead of an empty object.